### PR TITLE
Enable CSRF Protection during authentication. resolves #3

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,15 @@
 class ApplicationController < ActionController::Base
-  skip_before_action :verify_authenticity_token
+  before_action :set_csrf_cookie
+
+  private
 
   def logged_in
+  end
+
+  def set_csrf_cookie
+    cookies["CSRF-TOKEN"] = {
+      value: form_authenticity_token,
+      secure: true
+    }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module RailsAuthenticationApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.action_controller.forgery_protection_origin_check = false
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,5 @@
 if Rails.env == "production"
-  Rails.application.config.session_store :cookie_store, key: "_authentication_app", domain: "https://aeb-rails-authentication-app.herokuapp.com", httponly: true
+  Rails.application.config.session_store :cookie_store, key: "_authentication_app", domain: "https://aeb-rails-authentication-app.herokuapp.com", HttpOnly: true
 else
-  Rails.application.config.session_store :cookie_store, key: "_authentication_app", httponly: true
+  Rails.application.config.session_store :cookie_store, key: "_authentication_app", HttpOnly: true
 end


### PR DESCRIPTION
Cross Site Forgery Protection was temporarily bypassed. This PR enables it again, to improve security during authentication.